### PR TITLE
Add image corpus test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.14
+    resource_class: medium+
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,13 @@ jobs:
 
     steps:
       - checkout
+      - run:
+          name: Get test corpus etag
+          command: curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag > /tmp/exif-image-corpus-etag
       - restore_cache:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
-            - exif-image-corpus-v1-{{ checksum ".git/modules/testdata/exif-image-corpus/refs/heads/master" }}
+            - exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
       - run:
           name: Build
           command: go build
@@ -18,10 +21,10 @@ jobs:
           paths:
             - "/go/pkg/mod"
       - run:
-          name: Update submodules
-          command: git submodule update --init
+          name: Get test corpus
+          command: curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata/exif-image-corpus -xzv
       - save_cache:
-          key: exif-image-corpus-v1-{{ checksum ".git/modules/testdata/exif-image-corpus/refs/heads/master" }}
+          key: exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
           paths:
             - "testdata/exif-image-corpus"
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ jobs:
   test:
     docker:
       - image: circleci/golang:1.14
-    resource_class: medium+
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
+            - exif-image-corpus-v1-{{ checksum ".git/modules/testdata/exif-image-corpus/refs/heads/master" }}
       - run:
           name: Build
           command: go build
@@ -19,9 +20,13 @@ jobs:
       - run:
           name: Update submodules
           command: git submodule update --init
+      - save_cache:
+          key: exif-image-corpus-v1-{{ checksum ".git/modules/testdata/exif-image-corpus/refs/heads/master" }}
+          paths:
+            - "testdata/exif-image-corpus"
       - run:
           name: Run tests
-          command: go test ./... -v
+          command: go test . -v
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
             - "/go/pkg/mod"
       - run:
           name: Get test corpus
-          command: curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata/exif-image-corpus -xzv
+          command: curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata -xzv
       - save_cache:
           key: exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
           paths:
             - "/go/pkg/mod"
       - run:
+          name: Update submodules
+          command: git submodule update --init
+      - run:
           name: Run tests
           command: go test ./... -v
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
       - restore_cache:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
+      - restore_cache:
+          keys:
             - exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
       - run:
           name: Build
@@ -22,8 +24,8 @@ jobs:
           paths:
             - "/go/pkg/mod"
       - run:
-          name: Get test corpus
-          command: curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata -xzv
+          name: Get test corpus if it's not cached
+          command: "[ -d ./testdata/exif-image-corpus ] || curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata -xzv"
       - save_cache:
           key: exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
           paths:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "testdata/exif-samples"]
-	path = testdata/exif-samples
-	url = https://github.com/ianare/exif-samples.git
-[submodule "testdata/exif-image-corpus"]
-	path = testdata/exif-image-corpus
-	url = https://github.com/getlantern/exif-image-corpus

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "testdata/exif-samples"]
 	path = testdata/exif-samples
 	url = https://github.com/ianare/exif-samples.git
+[submodule "testdata/exif-image-corpus"]
+	path = testdata/exif-image-corpus
+	url = https://github.com/getlantern/exif-image-corpus

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testdata/exif-samples"]
+	path = testdata/exif-samples
+	url = https://github.com/ianare/exif-samples.git

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ $ ./meta-scrubber input-file.png output-file.png
 ```
 
 ## development
-metascrubber uses [exif-samples](https://github.com/ianare/exif-samples) as a image test corpus.
-In order to run tests on that corpus, you'll need to initialize the submodule:
+metascrubber uses [exif-samples](https://github.com/ianare/exif-samples) and [exif-image-corpus](https://github.com/getlantern/exif-image-corpus) as a image test corpuses.
+In order to run tests on those corpuses, you'll need to initialize the submodule:
 ```
 $ git clone https://github.com/getlantern/meta-scrubber.git
 $ cd meta-scrubber
 $ git submodule update --init
-$ go test ./...
+$ go test ./... -v
 ```

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ $ ./meta-scrubber input-file.png output-file.png
 ```
 
 ## development
-metascrubber uses [exif-samples](https://github.com/ianare/exif-samples) and [exif-image-corpus](https://github.com/getlantern/exif-image-corpus) as a image test corpuses.
-In order to run tests on those corpuses, you'll need to initialize the submodule:
+metascrubber will run tests on any `.jpg` or `.png` images in `testdata`.
+There's a large (currently ~1GB) corpus for testing at https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz
+To download and test:
 ```
 $ git clone https://github.com/getlantern/meta-scrubber.git
 $ cd meta-scrubber
-$ git submodule update --init
-$ go test ./... -v
+$ curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata/exif-image-corpus -xzv
+$ go test . -v
 ```

--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@ It is a WORK IN PROGRESS and currently provides ZERO guarantees and VERY limited
 $ go build ./cmd/meta-scrubber
 $ ./meta-scrubber input-file.png output-file.png
 ```
+
+## development
+metascrubber uses [exif-samples](https://github.com/ianare/exif-samples) as a image test corpus.
+In order to run tests on that corpus, you'll need to initialize the submodule:
+```
+$ git clone https://github.com/getlantern/meta-scrubber.git
+$ cd meta-scrubber
+$ git submodule update --init
+$ go test ./...
+```

--- a/jpeg.go
+++ b/jpeg.go
@@ -73,12 +73,7 @@ func (sr *scanReader) Read(p []byte) (n int, err error) {
 		}
 	}
 
-	var markerIndex int
-	if lastByteN == 1 {
-		markerIndex = firstMarker(append(p[:n], lastByte[0]))
-	} else {
-		markerIndex = firstMarker(p[:n])
-	}
+	markerIndex := firstMarker(append(p[:n], lastByte[:lastByteN]...))
 
 	if markerIndex >= 0 {
 		n = markerIndex

--- a/jpeg.go
+++ b/jpeg.go
@@ -100,6 +100,7 @@ func (jr *jpegSegmentReader) nextSegment() (r io.Reader, isMetadata bool, err er
 
 	// segment marker logic from:
 	// https://dev.exiv2.org/projects/exiv2/wiki/The_Metadata_in_JPEG_files
+	// https://github.com/dsoprea/go-jpeg-image-structure/blob/d40a386309d24fb714c60dcf1f5f88bff3ad9237/splitter.go#L219
 	var segmentLength int64
 
 	if bytes.Equal(segmentMarker, []byte{0xff, 0xd8}) {
@@ -113,8 +114,6 @@ func (jr *jpegSegmentReader) nextSegment() (r io.Reader, isMetadata bool, err er
 		// RST marker
 		segmentLength = 2
 	} else {
-		// TODO: double check potentially static-length markers????
-		// https://github.com/dsoprea/go-jpeg-image-structure/blob/d40a386309d24fb714c60dcf1f5f88bff3ad9237/splitter.go#L219
 		var segmentDataLength uint16
 		if err = binary.Read(teedReader, binary.BigEndian, &segmentDataLength); err != nil {
 			if !errors.Is(err, io.EOF) {
@@ -125,6 +124,7 @@ func (jr *jpegSegmentReader) nextSegment() (r io.Reader, isMetadata bool, err er
 
 		if bytes.Equal(segmentMarker, []byte{0xff, 0xda}) {
 			// SOS (start of scan) marker
+			// https://stackoverflow.com/questions/26715684/parsing-jpeg-sos-marker
 			jr.insideScan = true
 		}
 

--- a/jpeg.go
+++ b/jpeg.go
@@ -5,22 +5,88 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"io/ioutil"
 )
 
 var headerBytes []byte = []byte{0xff, 0xd8}
 
+// scanReader reads until the scan terminating bytes are encountered
+type scanReader struct {
+	reader *io.Reader
+}
+
+func firstMarker(p []byte) int {
+	markerIndex := -1
+	// Look for an 0xff followed by anything other than 0x00 or [0xd0-0xd7] (those are RST markers)
+	for i := 0x01; i <= 0xff; i++ {
+		if i >= 0xd0 && i <= 0xd7 {
+			continue
+		}
+		markerIndex = bytes.Index(p, []byte{0xff, byte(i)})
+		if markerIndex >= 0 {
+			return markerIndex
+		}
+	}
+	return markerIndex
+}
+
+func (sr *scanReader) Read(p []byte) (n int, err error) {
+	buf := new(bytes.Buffer)
+	teedReader := io.TeeReader(*sr.reader, buf)
+	if n, err = teedReader.Read(p); err != nil {
+		if errors.Is(err, io.EOF) {
+			return
+		}
+		err = &MalformedDataError{"unexpected error reading inside scan data", err}
+		return
+	}
+
+	// TODO:
+	// - what happens when a 2 byte marker overlaps the end of the buffer???
+
+	markerIndex := firstMarker(p[:n])
+
+	if markerIndex >= 0 {
+		n = markerIndex
+		if _, err = io.CopyN(ioutil.Discard, buf, int64(markerIndex)); err != nil {
+			return
+			// TODO: error handling??
+		}
+		*sr.reader = io.MultiReader(buf, *sr.reader)
+		if markerIndex == 0 {
+			err = io.EOF
+		}
+		return
+	}
+
+	return
+}
+
 type jpegSegmentReader struct {
-	reader io.Reader
+	reader     io.Reader
+	insideScan bool
+	endOfImage bool
 }
 
 func (jr *jpegSegmentReader) isMetadataType(segmentMarker []byte) bool {
 	// APP segments are of form 0xff, 0xe[0-f]
+	// more information about them at https://exiftool.org/TagNames/JPEG.html
+	// APP14 and APP15 *seem* to be required to actually decode image data
 	// COM segments are of form 0xff, 0xfe
 	return segmentMarker[0] == 0xff &&
-		((segmentMarker[1] >= 0xe0 && segmentMarker[1] <= 0xef) || segmentMarker[1] == 0xfe)
+		((segmentMarker[1] >= 0xe0 && segmentMarker[1] <= 0xed) || segmentMarker[1] == 0xfe)
 }
 
 func (jr *jpegSegmentReader) nextSegment() (r io.Reader, isMetadata bool, err error) {
+	if jr.endOfImage {
+		return nil, false, io.EOF
+	}
+
+	if jr.insideScan {
+		jr.insideScan = false
+		return &scanReader{&jr.reader}, false, nil
+	}
+
 	segmentHeaderBuffer := new(bytes.Buffer)
 	teedReader := io.TeeReader(jr.reader, segmentHeaderBuffer)
 
@@ -28,25 +94,26 @@ func (jr *jpegSegmentReader) nextSegment() (r io.Reader, isMetadata bool, err er
 	if _, err = io.ReadFull(teedReader, segmentMarker); err != nil {
 		if !errors.Is(err, io.EOF) {
 			err = &MalformedDataError{"can't parse jpeg segment marker", err}
+			return
 		}
-		return
 	}
 
 	// segment marker logic from:
 	// https://dev.exiv2.org/projects/exiv2/wiki/The_Metadata_in_JPEG_files
 	var segmentLength int64
 
-	if bytes.Equal(segmentMarker, []byte{0xff, 0xd8}) || bytes.Equal(segmentMarker, []byte{0xff, 0xd9}) {
-		// SOI (start of image) and EOI (end of image) markers respectively
+	if bytes.Equal(segmentMarker, []byte{0xff, 0xd8}) {
+		// SOI (start of image) marker
 		segmentLength = 2
+	} else if bytes.Equal(segmentMarker, []byte{0xff, 0xd9}) {
+		// EOI (end of image) marker
+		segmentLength = 2
+		jr.endOfImage = true
 	} else if segmentMarker[0] == 0xff && segmentMarker[1] >= 0xd0 && segmentMarker[1] <= 0xd7 {
 		// RST marker
 		segmentLength = 2
-	} else if bytes.Equal(segmentMarker, []byte{0xff, 0xdd}) {
-		// DRI marker
-		segmentLength = 4
 	} else {
-		// TODO: apparently there are some number of static-length markers????
+		// TODO: double check potentially static-length markers????
 		// https://github.com/dsoprea/go-jpeg-image-structure/blob/d40a386309d24fb714c60dcf1f5f88bff3ad9237/splitter.go#L219
 		var segmentDataLength uint16
 		if err = binary.Read(teedReader, binary.BigEndian, &segmentDataLength); err != nil {
@@ -54,6 +121,11 @@ func (jr *jpegSegmentReader) nextSegment() (r io.Reader, isMetadata bool, err er
 				err = &MalformedDataError{"can't parse jpeg data length", err}
 			}
 			return
+		}
+
+		if bytes.Equal(segmentMarker, []byte{0xff, 0xda}) {
+			// SOS (start of scan) marker
+			jr.insideScan = true
 		}
 
 		// 2 byte segmentDataLength + segmentDataLength (doesn't count marker bytes)

--- a/jpeg.go
+++ b/jpeg.go
@@ -33,30 +33,71 @@ func firstMarker(p []byte) int {
 func (sr *scanReader) Read(p []byte) (n int, err error) {
 	buf := new(bytes.Buffer)
 	teedReader := io.TeeReader(*sr.reader, buf)
-	if n, err = teedReader.Read(p); err != nil {
-		if errors.Is(err, io.EOF) {
+	// kick the underlying reader into giving us more than just one byte because the
+	// the naive multireader will just give us one byte from the first reader in its arguments
+	if len(p) > 1 {
+		if n, err = io.ReadAtLeast(teedReader, p, 2); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			} else if errors.Is(err, io.ErrUnexpectedEOF) {
+				// safe to just deal with on the next pass through
+				err = nil
+			} else {
+				err = &MalformedDataError{"unexpected error reading inside scan data", err}
+				return
+			}
+		}
+	} else {
+		// if len(p) is only 1, we can still attempt to read because we'll still
+		// peak the next byte and can act accordingly
+		if n, err = teedReader.Read(p); err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			err = &MalformedDataError{"unexpected error reading inside scan data", err}
 			return
 		}
-		err = &MalformedDataError{"unexpected error reading inside scan data", err}
-		return
 	}
 
-	// TODO:
-	// - what happens when a 2 byte marker overlaps the end of the buffer???
+	// attempt to peek one more byte to ensure that the marker doesn't overlap
+	// the bytes returned
+	lastByte := make([]byte, 1)
+	var lastByteN int
+	if lastByteN, err = io.ReadFull(teedReader, lastByte); err != nil {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+			// an EOF is ok here because we'll catch it normally on the next pass through
+			err = nil
+		} else {
+			err = &MalformedDataError{"unexpected error reading inside scan data", err}
+			return
+		}
+	}
 
-	markerIndex := firstMarker(p[:n])
+	var markerIndex int
+	if lastByteN == 1 {
+		markerIndex = firstMarker(append(p[:n], lastByte[0]))
+	} else {
+		markerIndex = firstMarker(p[:n])
+	}
 
 	if markerIndex >= 0 {
 		n = markerIndex
 		if _, err = io.CopyN(ioutil.Discard, buf, int64(markerIndex)); err != nil {
+			err = &MalformedDataError{"unexpected error reading inside scan data", err}
 			return
-			// TODO: error handling??
 		}
+
+		// pop "unread" bytes back onto reader
 		*sr.reader = io.MultiReader(buf, *sr.reader)
 		if markerIndex == 0 {
 			err = io.EOF
 		}
 		return
+	}
+
+	if lastByteN == 1 {
+		// pop the last byte back onto the reader
+		*sr.reader = io.MultiReader(bytes.NewReader(lastByte), *sr.reader)
 	}
 
 	return

--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -42,33 +42,43 @@ func TestScrubbingShortReader(t *testing.T) {
 	assert.Equal(t, shortBytes, actuallyRead)
 }
 
-func TestImageValidity(t *testing.T) {
+func TestPngCorpusValidity(t *testing.T) {
+	checkImageValidity(t, "png")
+}
+
+func TestJpgCorpusValidity(t *testing.T) {
+	checkImageValidity(t, "jpg")
+}
+
+func checkImageValidity(t *testing.T, imageType string) {
 	var files []string
 	var err error
 
 	root := "testdata"
 	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		ext := filepath.Ext(path)
-		if ext == ".jpeg" || ext == ".jpg" || ext == ".png" {
+		if imageType == "png" && ext == ".png" {
+			files = append(files, path)
+		} else if imageType == "jpg" && (ext == ".jpg" || ext == ".jpeg") {
 			files = append(files, path)
 		}
 		return nil
 	})
 	require.NoError(t, err)
 	for _, file := range files {
-		t.Logf("decoding %v", file)
 		inputImage, err := os.Open(file)
 		require.NoError(t, err)
-		defer inputImage.Close()
 		_, _, err = image.Decode(inputImage)
+		inputImage.Close()
 		if err == nil {
+			t.Logf("decoding %v", file)
 			inputImage, err := os.Open(file)
-			defer inputImage.Close()
 			require.NoError(t, err)
 			scrubberReader, err := GetScrubber(inputImage)
 			require.NoError(t, err)
 			_, _, err = image.Decode(scrubberReader)
-			require.NoError(t, err)
+			assert.NoErrorf(t, err, "could not decode %s after scrubbing", file)
+			inputImage.Close()
 		}
 	}
 }
@@ -82,33 +92,25 @@ func compareImages(t *testing.T, originalFilename string, expectedFilename strin
 	require.NoError(t, err)
 	actuallyRead, err := ioutil.ReadAll(imageScrubber)
 	require.NoError(t, err)
-	assert.Equal(t, expectedImageBytes, actuallyRead)
+	assert.Equalf(t, expectedImageBytes, actuallyRead, "expected %v to match %v after scrubbing", originalFilename, expectedFilename)
 }
 
-func TestScrubbingPngWithoutExif(t *testing.T) {
-	compareImages(t, "kitten-without-meta.png", "kitten-without-meta.png")
-}
+func TestScrubbing(t *testing.T) {
+	images := []struct {
+		originalFile string
+		expectedFile string
+	}{
+		{"kitten-without-meta.png", "kitten-without-meta.png"},
+		{"kitten-with-exif-description.png", "kitten-without-meta.png"},
+		{"kitten-with-text-author.png", "kitten-without-meta.png"},
+		{"kitten-with-xmp-manufacturer.png", "kitten-without-meta.png"},
+		{"kitten-without-meta.jpeg", "kitten-without-meta.jpeg"},
+		{"kitten-with-xmp-description.jpeg", "kitten-without-meta.jpeg"},
+		{"kitten-with-exif-make.jpeg", "kitten-without-meta.jpeg"},
+		{"kitten-with-exif-make.jpeg", "kitten-without-meta.jpeg"},
+	}
 
-func TestScrubbingPngWithExif(t *testing.T) {
-	compareImages(t, "kitten-with-exif-description.png", "kitten-without-meta.png")
-}
-
-func TestScrubbingPngWithTextAuthor(t *testing.T) {
-	compareImages(t, "kitten-with-text-author.png", "kitten-without-meta.png")
-}
-
-func TestScrubbingPngWithXMPManufacturer(t *testing.T) {
-	compareImages(t, "kitten-with-xmp-manufacturer.png", "kitten-without-meta.png")
-}
-
-func TestScrubbingJpegWithoutExif(t *testing.T) {
-	compareImages(t, "kitten-without-meta.jpeg", "kitten-without-meta.jpeg")
-}
-
-func TestScrubbingJpegWithXmpDescription(t *testing.T) {
-	compareImages(t, "kitten-with-xmp-description.jpeg", "kitten-without-meta.jpeg")
-}
-
-func TestScrubbingJpegWithExifMake(t *testing.T) {
-	compareImages(t, "kitten-with-exif-make.jpeg", "kitten-without-meta.jpeg")
+	for _, test := range images {
+		compareImages(t, test.originalFile, test.expectedFile)
+	}
 }


### PR DESCRIPTION
This adds a decent test corpus from https://github.com/ianare/exif-samples

Currently the test only checks that go's `image.Decode` function doesn't error on reading from the `metascrubber`s `io.Reader`.

I'm not sure this is the strongest guarantee that we're not corrupting/mishandling something, but I think it's a reasonable addition.