### PR TITLE
Cache test corpus in testdata

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Get test corpus etag
           command: |
-            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag | sed 's/ETag: //g' | sed 's/"//g' > /tmp/exif-image-corpus-etag
+            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag | sed 's/ETag: //g' | tr -d '\r\n' > /tmp/exif-image-corpus-etag
       - restore_cache:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - go-mod-v4-{{ checksum "go.sum" }}
       - restore_cache:
           keys:
-            - exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
+            - exif-image-corpus-v2-{{ checksum "/tmp/exif-image-corpus-etag" }}
       - run:
           name: Build
           command: go build
@@ -24,18 +24,13 @@ jobs:
           paths:
             - "/go/pkg/mod"
       - run:
-          name: Get test corpus if it's not cached
-          command: |
-            mkdir -p ./testdata/corpus
-            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata/corpus -xzv
-            cp /tmp/exif-image-corpus-etag ./testdata/corpus.etag
-      - save_cache:
-          key: exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
-          paths:
-            - "testdata/corpus"
-      - run:
           name: Run tests
           command: go test . -v
+      - save_cache:
+          key: exif-image-corpus-v2-{{ checksum "testdata/corpus.etag" }}
+          paths:
+            - "testdata/corpus"
+            - "testdata/corpus.etag"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - run:
           name: Get test corpus etag
           command: |
-            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag | sed 's/ETag: //g' > /tmp/exif-image-corpus-etag
+            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag | sed 's/ETag: //g' | sed 's/"//g' > /tmp/exif-image-corpus-etag
       - restore_cache:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,8 @@ jobs:
       - checkout
       - run:
           name: Get test corpus etag
-          command: curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag > /tmp/exif-image-corpus-etag
+          command: |
+            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz -I | grep -Fi ETag | sed 's/ETag: //g' > /tmp/exif-image-corpus-etag
       - restore_cache:
           keys:
             - go-mod-v4-{{ checksum "go.sum" }}
@@ -24,11 +25,14 @@ jobs:
             - "/go/pkg/mod"
       - run:
           name: Get test corpus if it's not cached
-          command: "[ -d ./testdata/exif-image-corpus ] || curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata -xzv"
+          command: |
+            mkdir -p ./testdata/corpus
+            curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata/corpus -xzv
+            cp /tmp/exif-image-corpus-etag ./testdata/corpus.etag
       - save_cache:
           key: exif-image-corpus-v1-{{ checksum "/tmp/exif-image-corpus-etag" }}
           paths:
-            - "testdata/exif-image-corpus"
+            - "testdata/corpus"
       - run:
           name: Run tests
           command: go test . -v

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# A test corpus, downloaded and cached when the tests are run
+testdata/corpus*

--- a/README.md
+++ b/README.md
@@ -14,11 +14,4 @@ $ ./meta-scrubber input-file.png output-file.png
 
 ## development
 metascrubber will run tests on any `.jpg` or `.png` images in `testdata`.
-There's a large (currently ~1GB) corpus for testing at https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz
-To download and test:
-```
-$ git clone https://github.com/getlantern/meta-scrubber.git
-$ cd meta-scrubber
-$ curl https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz | tar -C ./testdata/exif-image-corpus -xzv
-$ go test . -v
-```
+There's a large (currently ~1GB) corpus for testing at https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz. This corpus will be automatically downloaded and cached in `testdata` when the tests are first run. On future test runs, the corpus is checked for changes and, if necessary, updated. To avoid downloading/updating the corpus, or just to avoid testing against the corpus, run the tests with the `-short` flag.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/getlantern/meta-scrubber
 go 1.14
 
 require (
-	github.com/dsoprea/go-jpeg-image-structure v0.0.0-20200615034914-d40a386309d2
 	github.com/dsoprea/go-png-image-structure v0.0.0-20200615034826-4cfc78940228
 	github.com/jawher/mow.cli v1.1.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -5,15 +5,9 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dsoprea/go-exif/v2 v2.0.0-20200321225314-640175a69fe4/go.mod h1:Lm2lMM2zx8p4a34ZemkaUV95AnMl4ZvLbCUbwOvLC2E=
 github.com/dsoprea/go-exif/v2 v2.0.0-20200604193436-ca8584a0e1c4 h1:Mg7pY7kxDQD2Bkvr1N+XW4BESSIQ7tTTR7Vv+Gi2CsM=
 github.com/dsoprea/go-exif/v2 v2.0.0-20200604193436-ca8584a0e1c4/go.mod h1:9EXlPeHfblFFnwu5UOqmP2eoZfJyAZ2Ri/Vki33ajO0=
-github.com/dsoprea/go-iptc v0.0.0-20200609062250-162ae6b44feb h1:gwjJjUr6FY7zAWVEueFPrcRHhd9+IK81TcItbqw2du4=
-github.com/dsoprea/go-iptc v0.0.0-20200609062250-162ae6b44feb/go.mod h1:kYIdx9N9NaOyD7U6D+YtExN7QhRm+5kq7//yOsRXQtM=
-github.com/dsoprea/go-jpeg-image-structure v0.0.0-20200615034914-d40a386309d2 h1:8HmMqu64P4ZDGtcVwZDfmS4xuLXYjf2iery8teY7d9c=
-github.com/dsoprea/go-jpeg-image-structure v0.0.0-20200615034914-d40a386309d2/go.mod h1:ZoOP3yUG0HD1T4IUjIFsz/2OAB2yB4YX6NSm4K+uJRg=
 github.com/dsoprea/go-logging v0.0.0-20190624164917-c4f10aab7696/go.mod h1:Nm/x2ZUNRW6Fe5C3LxdY1PyZY5wmDv/s5dkPJ/VB3iA=
 github.com/dsoprea/go-logging v0.0.0-20200517223158-a10564966e9d h1:F/7L5wr/fP/SKeO5HuMlNEX9Ipyx2MbH2rV9G4zJRpk=
 github.com/dsoprea/go-logging v0.0.0-20200517223158-a10564966e9d/go.mod h1:7I+3Pe2o/YSU88W0hWlm9S22W7XI1JFNJ86U0zPKMf8=
-github.com/dsoprea/go-photoshop-info-format v0.0.0-20200609050348-3db9b63b202c h1:7j5aWACOzROpr+dvMtu8GnI97g9ShLWD72XIELMgn+c=
-github.com/dsoprea/go-photoshop-info-format v0.0.0-20200609050348-3db9b63b202c/go.mod h1:pqKB+ijp27cEcrHxhXVgUUMlSDRuGJJp1E+20Lj5H0E=
 github.com/dsoprea/go-png-image-structure v0.0.0-20200615034826-4cfc78940228 h1:GKAdOrszPH3mQ44eRg2kw9zBW0hi2L78ZNjkTx+cte0=
 github.com/dsoprea/go-png-image-structure v0.0.0-20200615034826-4cfc78940228/go.mod h1:aDYQkL/5gfRNZkoxiLTSWU4Y8/gV/4MVsy/MU9uwTak=
 github.com/dsoprea/go-utility v0.0.0-20200512094054-1abbbc781176 h1:CfXezFYb2STGOd1+n1HshvE191zVx+QX3A1nML5xxME=
@@ -21,8 +15,6 @@ github.com/dsoprea/go-utility v0.0.0-20200512094054-1abbbc781176/go.mod h1:95+K3
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.0.2 h1:xMxH9j2fNg/L4hLn/4y3M0IUsn0M6Wbu/Uh9QlOfBh4=
 github.com/go-errors/errors v1.0.2/go.mod h1:psDX2osz5VnTOnFWbDeWwS7yejl+uV3FEWEp4lssFEs=
-github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b h1:khEcpUM4yFcxg4/FHQWkvVRmgijNXRfzkIDHh23ggEo=
-github.com/go-xmlfmt/xmlfmt v0.0.0-20191208150333-d5b6f63a941b/go.mod h1:aUCEOzzezBEjDBbFBoSiya/gduyIiWYRP6CnSFIV8AM=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/geo v0.0.0-20200319012246-673a6f80352d h1:C/hKUcHT483btRbeGkrRjJz+Zbcj8audldIi9tRJDCc=
 github.com/golang/geo v0.0.0-20200319012246-673a6f80352d/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
@@ -46,6 +38,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=


### PR DESCRIPTION
This downloads/updates the test corpus when the tests are run.  You can use the `-short` flag to skip the update process and keep tests from running against the larger corpus (they'll still run against anything else in `testdata`).  If you are offline or if there is some other issue checking for updates, you'll get a message on stderr like
```
failed to update test corpus: HEAD failed: Head "https://meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com/exif-image-corpus.tar.gz": dial tcp: lookup meta-scrubber-test-corpus.s3.us-west-1.amazonaws.com: no such host
```
but the tests will still run against whatever is already downloaded.  When you update the corpus and run the tests, you'll see output on stderr like
```
ETag changed; downloading new test corpus
Successfully updated test corpus
```
Otherwise, there is no additional output; the tests just run like normal.

TL;DR, you can just `git clone` and `go test` to test against the corpus.  At any time, you can run `go test -short` to skip all the long-running stuff.

What do you think @max-b?