### PR TITLE
Fail fast in scrubber test if original image fails to decode

### DIFF
--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -105,17 +105,16 @@ func checkImageValidity(t *testing.T, imageType string) {
 		inputImage, err := os.Open(file)
 		require.NoError(t, err)
 		_, _, err = image.Decode(inputImage)
+		require.NoErrorf(t, err, "could not decode %s before scrubbing, image is probably bad test file", file)
 		inputImage.Close()
-		if err == nil {
-			t.Logf("decoding %v", file)
-			inputImage, err := os.Open(file)
-			require.NoError(t, err)
-			scrubberReader, err := GetScrubber(inputImage)
-			require.NoError(t, err)
-			_, _, err = image.Decode(scrubberReader)
-			assert.NoErrorf(t, err, "could not decode %s after scrubbing", file)
-			inputImage.Close()
-		}
+		t.Logf("decoding %v", file)
+		inputImage, err = os.Open(file)
+		require.NoError(t, err)
+		scrubberReader, err := GetScrubber(inputImage)
+		require.NoError(t, err)
+		_, _, err = image.Decode(scrubberReader)
+		assert.NoErrorf(t, err, "could not decode %s after scrubbing", file)
+		inputImage.Close()
 	}
 }
 

--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -12,7 +12,6 @@ import (
 	_ "image/png"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -44,7 +43,7 @@ func init() {
 		return
 	}
 	if err := updateCorpus(os.Stderr); err != nil {
-		log.Fatalf("failed to update test corpus: %v", err)
+		panic(fmt.Sprintf("failed to update test corpus: %v", err))
 	}
 }
 

--- a/scrubber_test.go
+++ b/scrubber_test.go
@@ -12,6 +12,7 @@ import (
 	_ "image/png"
 	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -43,7 +44,7 @@ func init() {
 		return
 	}
 	if err := updateCorpus(os.Stderr); err != nil {
-		fmt.Fprintln(os.Stderr, "failed to update test corpus:", err)
+		log.Fatalf("failed to update test corpus: %v", err)
 	}
 }
 


### PR DESCRIPTION
Addresses the concerns @hwh33 had in https://github.com/getlantern/meta-scrubber/pull/2#discussion_r448528363